### PR TITLE
Normalize logs

### DIFF
--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -26,5 +26,5 @@ from . import decorators
 from .decorators import param, route, version # this is for fluidity/convenience
 
 
-__version__ = '5.2.1'
+__version__ = '5.2.2'
 

--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -26,5 +26,5 @@ from . import decorators
 from .decorators import param, route, version # this is for fluidity/convenience
 
 
-__version__ = '5.0.1'
+__version__ = '5.2.0'
 

--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -26,5 +26,5 @@ from . import decorators
 from .decorators import param, route, version # this is for fluidity/convenience
 
 
-__version__ = '5.2.3'
+__version__ = '5.2.5'
 

--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -26,5 +26,5 @@ from . import decorators
 from .decorators import param, route, version # this is for fluidity/convenience
 
 
-__version__ = '5.2.0'
+__version__ = '5.2.1'
 

--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -26,5 +26,5 @@ from . import decorators
 from .decorators import param, route, version # this is for fluidity/convenience
 
 
-__version__ = '5.2.2'
+__version__ = '5.2.3'
 

--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -26,5 +26,5 @@ from . import decorators
 from .decorators import param, route, version # this is for fluidity/convenience
 
 
-__version__ = '5.2.6'
+__version__ = '5.2.7'
 

--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -26,5 +26,5 @@ from . import decorators
 from .decorators import param, route, version # this is for fluidity/convenience
 
 
-__version__ = '5.2.5'
+__version__ = '5.2.6'
 

--- a/endpoints/call.py
+++ b/endpoints/call.py
@@ -781,17 +781,17 @@ class Controller(object):
             else:
                 self.logger.info("Request {}method: {} {}".format(uuid, req.method, req.path))
 
-            self.logger.info("Request {}date: {}".format(
+            self.logger.debug("Request {}date: {}".format(
                 uuid,
                 datetime.datetime.utcfromtimestamp(start).strftime("%Y-%m-%dT%H:%M:%S.%f"),
             ))
 
             ip = req.ip
             if ip:
-                self.logger.info("Request {}IP address: {}".format(uuid, ip))
+                self.logger.debug("Request {}IP address: {}".format(uuid, ip))
 
             if 'authorization' in req.headers:
-                self.logger.info('Request {}auth: {}'.format(uuid, req.headers['authorization']))
+                self.logger.debug('Request {}auth: {}'.format(uuid, req.headers['authorization']))
 
             ignore_hs = set([
                 'accept-language',
@@ -804,7 +804,7 @@ class Controller(object):
             #hs = []
             for k, v in req.headers.items():
                 if k not in ignore_hs:
-                    self.logger.info("Request {}header {}: {}".format(uuid, k, v))
+                    self.logger.debug("Request {}header {}: {}".format(uuid, k, v))
                     #hs.append("Request header: {}: {}".format(k, v))
 
             #self.logger.info(os.linesep.join(hs))
@@ -845,13 +845,29 @@ class Controller(object):
             uuid += " "
 
         for k, v in res.headers.items():
-            self.logger.info("Request {}response header {}: {}".format(uuid, k, v))
+            self.logger.debug("Request {}response header {}: {}".format(uuid, k, v))
 
         stop = time.time()
         get_elapsed = lambda start, stop, multiplier, rnd: round(abs(stop - start) * float(multiplier), rnd)
         elapsed = get_elapsed(start, stop, 1000.00, 1)
         total = "%0.1f ms" % (elapsed)
-        self.logger.info("Request {}response {} {} in {}".format(
+
+        body = ""
+        if req.has_body():
+            body = dict(req.body_kwargs)
+            if body:
+                for k in logging.IGNORE_KEYS:
+                    if k in body:
+                        body[k] = "****"
+                self.logger.debug("BODY: {}".format(body))
+
+        log_value = f"{req.method} {req.path} {res.code} {res.status} BODY: {body} uuid:{uuid} in {total} "
+        if req.path == "/ping":
+            self.logger.debug(log_value)
+        else:
+            self.logger.info(log_value)
+
+        self.logger.debug("Request {}response {} {} in {}".format(
             uuid,
             self.response.code,
             self.response.status,

--- a/endpoints/call.py
+++ b/endpoints/call.py
@@ -856,7 +856,14 @@ class Controller(object):
         if req.has_body():
             body = dict(req.body_kwargs)
             if body:
-                for k in logging.IGNORE_KEYS:
+                IGNORE_KEYS = [
+                    # bugsnag chokes on unicode keys so these have to be byte strings
+                    b"password",
+                    b"sensitive",
+                    b"ssn",
+                    b"dob",
+                ]
+                for k in IGNORE_KEYS:
                     if k in body:
                         body[k] = "****"
                 self.logger.debug("BODY: {}".format(body))

--- a/endpoints/call.py
+++ b/endpoints/call.py
@@ -777,9 +777,9 @@ class Controller(object):
                 uuid += " "
 
             if req.query:
-                self.logger.info("Request {}method: {} {}?{}".format(uuid, req.method, req.path, req.query))
+                self.logger.debug("Request {}method: {} {}?{}".format(uuid, req.method, req.path, req.query))
             else:
-                self.logger.info("Request {}method: {} {}".format(uuid, req.method, req.path))
+                self.logger.debug("Request {}method: {} {}".format(uuid, req.method, req.path))
 
             self.logger.debug("Request {}date: {}".format(
                 uuid,

--- a/endpoints/call.py
+++ b/endpoints/call.py
@@ -869,7 +869,7 @@ class Controller(object):
                 self.logger.debug("BODY: {}".format(body))
         body_str = ''.join(str(body).splitlines())
 
-        log_value = f"REQUEST m:{req.method} p:{req.path} result:{res.code} BODY:\"{body_str}\" uuid:{uuid} in {total} "
+        log_value = f"REQUEST {req.method} {req.path} {res.code} BODY:\"{body_str}\" uuid:{uuid} in {total} "
         if req.path == "/ping":
             self.logger.debug(log_value)
         else:

--- a/endpoints/call.py
+++ b/endpoints/call.py
@@ -868,7 +868,7 @@ class Controller(object):
                         body[k] = "****"
                 self.logger.debug("BODY: {}".format(body))
 
-        log_value = f"{req.method} {req.path} {res.code} {res.status} BODY: {body} uuid:{uuid} in {total} "
+        log_value = f"REQUEST m:{req.method} p:{req.path} result:{res.code} BODY:\"{body}\" uuid:{uuid} in {total} "
         if req.path == "/ping":
             self.logger.debug(log_value)
         else:

--- a/endpoints/call.py
+++ b/endpoints/call.py
@@ -867,8 +867,9 @@ class Controller(object):
                     if k in body:
                         body[k] = "****"
                 self.logger.debug("BODY: {}".format(body))
+        body_str = ''.join(str(body).splitlines())
 
-        log_value = f"REQUEST m:{req.method} p:{req.path} result:{res.code} BODY:\"{body}\" uuid:{uuid} in {total} "
+        log_value = f"REQUEST m:{req.method} p:{req.path} result:{res.code} BODY:\"{body_str}\" uuid:{uuid} in {total} "
         if req.path == "/ping":
             self.logger.debug(log_value)
         else:

--- a/endpoints/call.py
+++ b/endpoints/call.py
@@ -857,23 +857,28 @@ class Controller(object):
             body = dict(req.body_kwargs)
             if body:
                 IGNORE_KEYS = [
-                    # bugsnag chokes on unicode keys so these have to be byte strings
-                    b"password",
-                    b"sensitive",
-                    b"ssn",
-                    b"dob",
+                    "password",
+                    "sensitive",
+                    "ssn",
+                    "dob",
                 ]
                 for k in IGNORE_KEYS:
                     if k in body:
                         body[k] = "****"
                 self.logger.debug("BODY: {}".format(body))
-        body_str = ''.join(str(body).splitlines())
 
-        log_value = f"REQUEST {req.method} {req.path} {res.code} BODY:\"{body_str}\" uuid:{uuid} in {total} "
-        if req.path == "/ping":
+        body_str = ''.join(str(body).splitlines())
+        body_param = f"BODY:\"{body_str}\""
+
+        log_value = f"REQUEST {req.method} {req.path} {res.code} {body_param} uuid:{uuid} in {total} "
+        if req.path == "/ping" or req.path == "/track/event":
             self.logger.debug(log_value)
         else:
+            if req.path == "/track/event":
+                log_value = f"REQUEST {req.method} {req.path} {res.code} uuid:{uuid} in {total} "
+
             self.logger.info(log_value)
+
 
         self.logger.debug("Request {}response {} {} in {}".format(
             uuid,

--- a/endpoints/call.py
+++ b/endpoints/call.py
@@ -871,7 +871,7 @@ class Controller(object):
         body_param = f"BODY:\"{body_str}\""
 
         log_value = f"REQUEST {req.method} {req.path} {res.code} {body_param} uuid:{uuid} in {total} "
-        if req.path == "/ping" or req.path == "/track/event":
+        if req.path == "/ping":
             self.logger.debug(log_value)
         else:
             if req.path == "/track/event":


### PR DESCRIPTION
We need a way to log only the request with the status code instead of logging everything from the request. 
To accomplish that, we changed the log level for some of the logging of the request and created a new line to log INFO when a response will be sent.

Now every request is logged as following:
`REQUEST POST /chat/read 200 BODY:"{'room_id': 000}" uuid:xxxxxxxxxxxx-47e7-9ca4-xxxxxxxx  in 377.5 ms`

`REQUEST GET /v2/symptoms/tracking 200 BODY:"" uuid:xxxxxxxxxx-45a5-90e8-xxxxxxxx  in 26.5 ms`


## Improvements

Some endpoints like /ping will not be logged.
Some special keys will not be logged on the body
